### PR TITLE
YandexDirect is Closable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>ru.cultserv.adv</groupId>
   <artifactId>yandex-direct-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.2</version>
+  <version>1.3-SNAPSHOT</version>
   <name>yandex-direct-client</name>
   <url>http://maven.apache.org</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>ru.cultserv.adv</groupId>
   <artifactId>yandex-direct-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.2</version>
   <name>yandex-direct-client</name>
   <url>http://maven.apache.org</url>
   

--- a/src/main/java/ru/cultserv/adv/util/AbstractApiRequestExecutor.java
+++ b/src/main/java/ru/cultserv/adv/util/AbstractApiRequestExecutor.java
@@ -1,6 +1,7 @@
 package ru.cultserv.adv.util;
 
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.Request;
@@ -21,6 +22,8 @@ public abstract class AbstractApiRequestExecutor implements ApiRequestExecutor {
 
     @Override
 	public ApiResponse execute(ApiRequest request) {
+		Preconditions.checkState(!client.isClosed(), "request executor is closed");
+
 		Future<ApiResponse> future = asFuture(request);
 		try {
 			return future.get();
@@ -60,7 +63,12 @@ public abstract class AbstractApiRequestExecutor implements ApiRequestExecutor {
 	protected void withParams(final ApiRequestParams params, final RequestBuilder builder) {
 		builder.setBody(Json.toJson(params).toString());
 	}
-	
+
+	@Override
+	public void close() {
+		client.close();
+	}
+
 	protected abstract ApiResponse process(Response response);
 
 }

--- a/src/main/java/ru/cultserv/adv/util/ApiRequestExecutor.java
+++ b/src/main/java/ru/cultserv/adv/util/ApiRequestExecutor.java
@@ -1,11 +1,15 @@
 package ru.cultserv.adv.util;
 
+import java.io.Closeable;
 import java.util.concurrent.Future;
 
-public interface ApiRequestExecutor {
+public interface ApiRequestExecutor extends Closeable {
 
 	ApiResponse execute(ApiRequest request);
 
 	Future<ApiResponse> asFuture(ApiRequest request);
+
+	@Override
+	void close();
 
 }

--- a/src/main/java/ru/cultserv/adv/yandex/direct/YandexDirect.java
+++ b/src/main/java/ru/cultserv/adv/yandex/direct/YandexDirect.java
@@ -2,7 +2,9 @@ package ru.cultserv.adv.yandex.direct;
 
 import ru.cultserv.adv.yandex.direct.methods.*;
 
-public interface YandexDirect {
+import java.io.Closeable;
+
+public interface YandexDirect extends Closeable {
 
 	/**
 	 * Доступ к методам для работы с рекламными кампаниями

--- a/src/main/java/ru/cultserv/adv/yandex/direct/impl/YandexDirectImpl.java
+++ b/src/main/java/ru/cultserv/adv/yandex/direct/impl/YandexDirectImpl.java
@@ -63,4 +63,9 @@ public class YandexDirectImpl implements YandexDirect {
     private <T> T create(Class<T> targetInterface) {
 		return ProxyBuilder.create(targetInterface, caller);
 	}
+
+	@Override
+	public void close() {
+		caller.close();
+	}
 }

--- a/src/main/java/ru/cultserv/adv/yandex/direct/util/requests/YandexDirectMethodCaller.java
+++ b/src/main/java/ru/cultserv/adv/yandex/direct/util/requests/YandexDirectMethodCaller.java
@@ -8,7 +8,9 @@ import ru.cultserv.adv.util.AsyncClientFactory;
 import ru.cultserv.adv.yandex.direct.AuthToken;
 import ru.cultserv.adv.yandex.direct.methods.MethodName;
 
-public class YandexDirectMethodCaller {
+import java.io.Closeable;
+
+public class YandexDirectMethodCaller implements Closeable {
 	
 	private final AuthToken token;
 	private final ApiRequestExecutor executor;
@@ -52,4 +54,8 @@ public class YandexDirectMethodCaller {
 		return prepared(token, AsyncClientFactory.getClient());
 	}
 
+	@Override
+	public void close() {
+		executor.close();
+	}
 }


### PR DESCRIPTION
YandexDirect uses AsyncHttpClient internally. To avoid memory leak client should be closed after use of direct client.
